### PR TITLE
fix(navbar): implement backend logout before frontend sign out

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -95,11 +95,30 @@ export default function Navbar() {
     setOpen((o) => !o);
   };
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
     if (isAdminAuthenticated) {
       adminLogout();
       window.location.href = '/admin/login';
     } else {
+      // Call backend logout endpoint before signing out
+      try {
+        const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL ?? '';
+        const token = session?.backendToken;
+
+        if (token) {
+          await fetch(`${backendUrl}/auth/logout`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${token}`,
+              'Content-Type': 'application/json',
+            },
+          });
+        }
+      } catch (error) {
+        console.error('Backend logout failed:', error);
+        // Continue with frontend logout even if backend fails
+      }
+
       signOut({ callbackUrl: '/' });
     }
     setOpen(false);


### PR DESCRIPTION
## Description

- Attach logout API in logout button on Navbar

## Functional Acceptance Criteria (Not required for Documentation update)

Logged out user's token is revoked after logging out

## Checklist
- [ ] Linked issue
- [x] Linked GitHub Project item
- [ ] Tests added/updated
- [x] CI green (build, tests, SonarQube)
- [x] My code follows the Coding Guidelines.

## Screenshots / Demos
<img width="2892" height="768" alt="image" src="https://github.com/user-attachments/assets/c5ae12c8-238b-4437-9a37-8752af4935e6" />